### PR TITLE
Include area_name in automatic ID

### DIFF
--- a/lib/gobierto_data/gobierto_budgets/budget_line_csv_row.rb
+++ b/lib/gobierto_data/gobierto_budgets/budget_line_csv_row.rb
@@ -151,7 +151,8 @@ module GobiertoData
           organization_id,
           year,
           area_code,
-          kind
+          kind,
+          area_name
         ].join("/")
       end
 


### PR DESCRIPTION
This PR adds a small fix to include the area_name in the automatic ID generated on import